### PR TITLE
Use Husky for csharpier pre commit hook

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "dotnet-csharpier"
       ]
+    },
+    "husky": {
+      "version": "0.4.2",
+      "commands": [
+        "husky"
+      ]
     }
   }
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+dotnet husky run

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,10 @@
+{
+  "tasks": [{
+    "name": "Run csharpier",
+    "command": "dotnet",
+    "args": [ "csharpier", "${staged}"  ],
+    "include": [ "**/*.cs"  ]
+
+  }]
+
+}

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@
 1. Install [Unity Hub](https://unity3d.com/get-unity/download)
    1. Install Unity 2021.3
 2. Install the tools found in the manifest [here](./.config/dotnet-tools.json)
-3. Run `cp Scripts/git_hooks/pre-commit .git/hooks/pre-commit`. 
-   1. Since git_hooks have to be under `.git` they don't get get checked into source control, so we have to manage them in a different repo.
 4. Run `git config --global core.autocrlf true`
    1. This helps with the difference between windows and unix line endings (I think)
 5. Add the unity tools directory https://docs.unity3d.com/Manual/SmartMerge.html to your path. We specifically want `UnityYAMLMerge.exe` available to git

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 1. Install [Unity Hub](https://unity3d.com/get-unity/download)
    1. Install Unity 2021.3
 2. Install the tools found in the manifest [here](./.config/dotnet-tools.json)
+   1. `dotnet tool restore`
+   2. `dotnet husky install`
 4. Run `git config --global core.autocrlf true`
    1. This helps with the difference between windows and unix line endings (I think)
 5. Add the unity tools directory https://docs.unity3d.com/Manual/SmartMerge.html to your path. We specifically want `UnityYAMLMerge.exe` available to git

--- a/Scripts/git_hooks/pre-commit
+++ b/Scripts/git_hooks/pre-commit
@@ -1,4 +1,0 @@
-#!bin/sh
-
-echo "Running: dotnet csharpier ./Assets/Scripts"
-dotnet csharpier ./Assets/Scripts


### PR DESCRIPTION
Use the suggested docs for establishing precommit hooks for csharpier https://csharpier.com/docs/Pre-commit

This way we don't need to manually copy anything to get precommit hooks set up on the project. All we need to do is install the relevant dotnet dependencies