### PR TITLE
Fixes player prefab to have energy on be default, tweaks energy logic

### DIFF
--- a/Assets/Levels/Sandbox.unity
+++ b/Assets/Levels/Sandbox.unity
@@ -202,6 +202,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 20daa800a641d9e4cae18a06630db1ef, type: 3}
+    - target: {fileID: 8141005924980681431, guid: 2f0f76ea492fa6346946676847076255, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2f0f76ea492fa6346946676847076255, type: 3}
 --- !u!1 &91001227
@@ -1107,18 +1111,6 @@ PrefabInstance:
       value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 817833974993414891, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 817833974993414891, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 817833974993414891, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 817833974993414891, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.7
       objectReference: {fileID: 0}
@@ -1158,45 +1150,12 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1481507867024084348, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: health
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1481507867024084348, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: isPlayer
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1481507867024084348, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: turnController
-      value: 
-      objectReference: {fileID: 91001228}
-    - target: {fileID: 3698332608906112910, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: timer
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3698332608906112910, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: cooldown
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3698332608906112910, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: firePoint
-      value: 
-      objectReference: {fileID: 1481507867024084347}
     - target: {fileID: 3976692843403402619, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    - target: {fileID: 8887210594514678503, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 20daa800a641d9e4cae18a06630db1ef, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
---- !u!4 &1481507867024084347 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4617395206209494989, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
-  m_PrefabInstance: {fileID: 1481507867024084346}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1517813075447118209
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemy Variant.prefab
+++ b/Assets/Prefabs/Enemy Variant.prefab
@@ -67,6 +67,10 @@ PrefabInstance:
       propertyPath: health
       value: 100
       objectReference: {fileID: 0}
+    - target: {fileID: 2085307539277656526, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3698332608906112910, guid: 60a5383418e77de418a274d0da6e30e7, type: 3}
       propertyPath: timer
       value: 1

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -106,6 +106,51 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 069fdc5c8fde477e8a6eae264b826190, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2085307539277656526
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5116510120491384531}
+  - component: {fileID: 6463616329247216148}
+  m_Layer: 0
+  m_Name: PlayerEnergy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5116510120491384531
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2085307539277656526}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 817833974993414891}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6463616329247216148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2085307539277656526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 560c654cf5014a29a54fd8a2df0492b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  energy: 100
 --- !u!1 &2196871716378911944
 GameObject:
   m_ObjectHideFlags: 0
@@ -174,6 +219,7 @@ Transform:
   - {fileID: 4617395206209494989}
   - {fileID: 1584576572922779594}
   - {fileID: 6577409753331958608}
+  - {fileID: 5116510120491384531}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -218,7 +264,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: c96b02b971b0a4243881a4f47f4d3179, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 20daa800a641d9e4cae18a06630db1ef, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Scripts/Characters/Player.cs
+++ b/Assets/Scripts/Characters/Player.cs
@@ -37,22 +37,43 @@ namespace Characters
             }
 
             PlayerEnergy.EnergyExhausted += HandleEnergyExhausted;
-        }
-
-        private void HandleEnergyExhausted()
-        {
-            _playerMovement.gameObject.SetActive(false);
-            _playerCombat.gameObject.SetActive(false);
-        }
-
-        private void Start()
-        {
-            PlayerSpawned?.Invoke(this);
+            PlayerEnergy.EnergyReset += HandleEnergyReset;
         }
 
         private void OnDestroy()
         {
             PlayerDespawned?.Invoke(this);
+            PlayerEnergy.EnergyExhausted -= HandleEnergyExhausted;
+            PlayerEnergy.EnergyReset -= HandleEnergyReset;
+        }
+
+        private void HandleEnergyExhausted()
+        {
+            if (_playerMovement)
+            {
+                _playerMovement.gameObject.SetActive(false);
+            }
+            if (_playerCombat)
+            {
+                _playerCombat.gameObject.SetActive(false);
+            }
+        }
+
+        private void HandleEnergyReset()
+        {
+            if (_playerMovement)
+            {
+                _playerMovement.gameObject.SetActive(true);
+            }
+            if (_playerCombat)
+            {
+                _playerCombat.gameObject.SetActive(true);
+            }
+        }
+
+        private void Start()
+        {
+            PlayerSpawned?.Invoke(this);
         }
 
         public float GetHealth()

--- a/Assets/Scripts/Characters/PlayerCombat.cs
+++ b/Assets/Scripts/Characters/PlayerCombat.cs
@@ -15,9 +15,12 @@ namespace Characters
 
         private void Awake()
         {
-            _playerInput = GetComponentInParent<PlayerInput>();
             _playerInput.actions["Player/Fire"].performed += HandleFire;
+        }
 
+        private void OnEnable()
+        {
+            _playerInput = GetComponentInParent<PlayerInput>();
             _animator = GetComponentInParent<Animator>();
             _weapon = GetComponentInParent<Weapon>();
             _body = GetComponentInParent<Rigidbody2D>();

--- a/Assets/Scripts/Characters/PlayerEnergy.cs
+++ b/Assets/Scripts/Characters/PlayerEnergy.cs
@@ -11,6 +11,7 @@ namespace Characters
         private float energy = 100f;
 
         public static event Action EnergyExhausted;
+        public static event Action EnergyReset;
 
         private EnergyLabel _energyLabel;
         private PlayerInput _playerInput;
@@ -20,7 +21,7 @@ namespace Characters
         {
             _energyLabel = FindObjectOfType<EnergyLabel>();
 
-            _playerInput = GetComponent<PlayerInput>();
+            _playerInput = GetComponentInParent<PlayerInput>();
 
             _playerInput.actions["Player/Fire"].performed += HandleFire;
             _playerInput.actions["Player/ResetEnergy"].performed += ResetEnergy;
@@ -56,7 +57,9 @@ namespace Characters
 
         private void ResetEnergy(InputAction.CallbackContext context)
         {
+            EnergyReset?.Invoke();
             energy = 100f;
+            _energyLabel.SetEnergy(energy);
         }
 
         private void HandleFire(InputAction.CallbackContext context)


### PR DESCRIPTION
There were two issues. The `PlayerEnergy` script wasn't attached, and the enemy variants were throwing NPEs when trying to disable PlayerCombat and PlayerMovement. I guess that will just break the behavior for all prefab types Or maybe everything happening on that update loop?

`if(_playerMovement)` is safe here because the enemy variants have the player movement and combat components disabled by default. Disable components won't be found with `GetComponent`. I think we still need to work on the player/enemy differentiation a bit more, or else doing things like setting up AI in the future is going to be difficult. 

I added `PlayerEnergy` to the prefab for the player. I initially was thinking we could add that conditionally based on the level. But it makes more sense to make it a game object and disable/enable it based on that. 